### PR TITLE
New google API domain with valid SSL

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -271,7 +271,7 @@ class PeopleController < ApplicationController
     end
     chd.chop!
     chl.chop!
-    @chart_url = "http://chart.apis.google.com/chart?cht=p&chco=346090&chs=350x100&#{chd}&#{chl}"
+    @chart_url = "https://chart.googleapis.com/chart?cht=p&chco=346090&chs=350x100&#{chd}&#{chl}"
 
     render :update do |page|
       page.replace_html "loading_reftype_chart", "<img src='#{@chart_url}' alt='work-type chart' style='margin-left: -50px;margin-bottom:20px;' />"

--- a/app/helpers/google_charts_helper.rb
+++ b/app/helpers/google_charts_helper.rb
@@ -13,7 +13,7 @@ module GoogleChartsHelper
     end
     chd.chop!
     chl.chop!
-    "http://chart.apis.google.com/chart?cht=p&chco=346090&chs=350x100&#{chd}&#{chl}"
+    "https://chart.googleapis.com/chart?cht=p&chco=346090&chs=350x100&#{chd}&#{chl}"
   end
 
 end


### PR DESCRIPTION
https://chart.googleapis.com/ is the only domain with valid SSL, old domain is deprecated. This creates insecure content warning in most of the browsers.
